### PR TITLE
Isa codigos modal

### DIFF
--- a/cursos/templates/cursos/inicio_curso.html
+++ b/cursos/templates/cursos/inicio_curso.html
@@ -127,7 +127,7 @@
                 {% if clase.publica or not usuaria.es_alumna %}
                     <li class="collection-item publica{{ clase.publica }} items-clase">
                         <div id="clase_{{ clase.id }}" class="collection-info">
-                            <p><b>{{ clase.nombre }}</b> <span id="la-fecha" class="letra_gris fecha_clase" style="font-size: smaller">&nbsp; {{ clase.fecha_clase }}</span></p>
+                            <p><b>{{ clase.nombre }}</b> <span id="la-fecha" class="fecha-texto fecha_clase">&nbsp; {{ clase.fecha_clase }}</span></p>
                             <div style="display: flex; align-items: center">
                                 {% if user.es_profesora %}
                                     {% if clase.publica %} <p>Publicada</p>

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -17,6 +17,10 @@ class Feedback(models.Model):
     def __str__(self):
         return str(self.user) + ":" + str(self.problema)
 
+    def display_solucion(self):
+        self.codigo_solucion.open()
+        return self.codigo_solucion.file.read().replace(b'\n', b'<br>').replace(b'  ', b'&nbsp')
+
 
 class TestFeedback(models.Model):
     passed = models.BooleanField(help_text="Si el test paso o no")

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -5,6 +5,8 @@ from django.db import models
 from problemas.models import Problema, Caso
 from usuarios.models import User
 
+from html import escape
+
 
 class Feedback(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, help_text="Usuaria dueña del feedback.")
@@ -19,7 +21,8 @@ class Feedback(models.Model):
 
     def display_solucion(self):
         self.codigo_solucion.open()
-        return self.codigo_solucion.file.read().replace(b'\n', b'<br>').replace(b'  ', b'&nbsp')
+        aux = escape(self.codigo_solucion.file.read().decode())
+        return aux.encode().replace(b'\n', b'<br>').replace(b'  ', b'&nbsp')
 
 
 class TestFeedback(models.Model):

--- a/feedback/views.py
+++ b/feedback/views.py
@@ -9,11 +9,9 @@ from django.utils.decorators import method_decorator
 from django.views import View
 
 from NiñasProject.decorators import docente_required
-from clases.models import Clase
-from cursos.models import Curso
 from feedback.forms import OutputAlternativoModelFormSet
 from feedback.models import OutputAlternativo, Feedback, TestFeedback
-from problemas.models import Caso, Problema
+from problemas.models import Caso
 
 
 @method_decorator([docente_required], name='dispatch')
@@ -23,7 +21,6 @@ class CasosAlternativos(LoginRequiredMixin, View):
             id_caso = request.GET.get('id')
             problema = request.GET.get('problema')
 
-            #problema = Problema.objects.get(id=id_problema)
             caso = Caso.objects.get(id=id_caso)
 
             # outputs_sugeridos = OutputAlternativo.objects.filter(caso=caso, agregado=False, frecuencia__gt=1)
@@ -39,7 +36,7 @@ class CasosAlternativos(LoginRequiredMixin, View):
                                               fecha_envio=feedback['ultima_fecha'])
                 ultimos_feedbacks.append(ultimo)
 
-            tests_caso = TestFeedback.objects.filter(caso=caso)
+            tests_caso = TestFeedback.objects.filter(caso=caso).order_by('-feedback__fecha_envio')
 
             context = {
                 'id_caso': id_caso,

--- a/problemas/templates/problemas/casos_prueba.html
+++ b/problemas/templates/problemas/casos_prueba.html
@@ -6,9 +6,11 @@
                 <span> <i class="material-icons">expand_more</i>{{ categoria.categoria }}</span>
 
                     {% with nuevos_outputs|output_exists:categoria.casos as outputs_cat %}
-                        {% if outputs_cat > 0 %}
-                        <span class="big-badge">{{  nuevos_outputs|output_exists:categoria.casos }}</span>
-                    {% endif %}
+                        {% if outputs_cat == 1 %}
+                            <span class="big-badge">{{  nuevos_outputs|output_exists:categoria.casos }} nuevo output</span>
+                        {% elif outputs_cat > 1 %}
+                            <span class="big-badge">{{  nuevos_outputs|output_exists:categoria.casos }} nuevos outputs</span>
+                        {% endif %}
                     {% endwith %}
 
             </div>

--- a/problemas/templates/problemas/casos_prueba.html
+++ b/problemas/templates/problemas/casos_prueba.html
@@ -1,7 +1,7 @@
 {% load template_tags %}
 <ul class="collapsible expandable">
     {% for categoria in casos %}
-        <li class="active">
+        <li>
             <div class="collapsible-header">
                 <i class="material-icons">expand_more</i>
                 {{ categoria.categoria }}

--- a/problemas/templates/problemas/casos_prueba.html
+++ b/problemas/templates/problemas/casos_prueba.html
@@ -22,12 +22,18 @@
                                     <td class="consolas">{{ caso.input }}</td>
                                     <td class="consolas output">{{ caso.output_esperado }}</td>
                                     <td>
-                                        <button class="open-modal btn btn-small" id="{{ caso.id }}">
-                                            Ver
-                                        </button>
                                         {% with nuevos_outputs|lookup:caso.id as nuevos %}
                                             {% if nuevos > 0  %}
-                                                <span class="new badge " data-badge-caption="Nuevos outputs"> {{ nuevos_outputs | lookup:caso.id }}</span>
+
+                                                <button class="open-modal btn btn-small notification" id="{{ caso.id }}">
+                                                    <span>Ver</span>
+                                                    <span class="badge" id="num-notif"> {{ nuevos_outputs | lookup:caso.id }}</span>
+                                                </button>
+
+                                            {% else %}
+                                                <button class="open-modal btn btn-small notification" id="{{ caso.id }}">
+                                                    <span>Ver</span>
+                                                </button>
                                             {% endif %}
                                         {% endwith %}
                                     </td>

--- a/problemas/templates/problemas/casos_prueba.html
+++ b/problemas/templates/problemas/casos_prueba.html
@@ -1,10 +1,16 @@
 {% load template_tags %}
 <ul class="collapsible expandable">
     {% for categoria in casos %}
-        <li>
-            <div class="collapsible-header">
-                <i class="material-icons">expand_more</i>
-                {{ categoria.categoria }}
+        <li id="casos-categoria">
+            <div class="collapsible-header" style="justify-content: space-between">
+                <span> <i class="material-icons">expand_more</i>{{ categoria.categoria }}</span>
+
+                    {% with nuevos_outputs|output_exists:categoria.casos as outputs_cat %}
+                        {% if outputs_cat > 0 %}
+                        <span class="big-badge">{{  nuevos_outputs|output_exists:categoria.casos }}</span>
+                    {% endif %}
+                    {% endwith %}
+
             </div>
             <div class="collapsible-body">
                 <div style="max-width: 100%; overflow-x:auto">

--- a/problemas/templates/problemas/modal_casos_alternativos.html
+++ b/problemas/templates/problemas/modal_casos_alternativos.html
@@ -36,40 +36,39 @@
                                             <td>{{ form.sugerencia }}</td>
                                         </tr>
                                         <tr class="row_bad_feedback">
-                                            <th class="codigos-casos letra_rosada" colspan="2" >
-                                                <ul class="collapsible expandable">
-                                                    <li>
+                                            <th class="codigos-casos" colspan="2">
+                                                <ul class="collapsible expandable no-sombra">
+                                                    <li class="codigos-header">
                                                         <div class="collapsible-header">
-                                                            <i class="material-icons">expand_more</i>
-                                                            Códigos ({{ form.instance.frecuencia }})
+                                                            <div class="btn btn-small">
+                                                                <i class="material-icons" style="vertical-align: middle">expand_more</i>
+                                                                <span>CÓDIGOS ({{ form.instance.frecuencia }})</span>
+                                                            </div>
                                                         </div>
-                                                        <div class="collapsible-body" style="text-align: left;color:black">
-
-                                                            {% for i in tests_caso %}
-
-                                                                    <p><span>{{ i.feedback.user }}</span><span class="letra_gris" style="font-size: smaller">&nbsp;{{ i.feedback.fecha_envio }}</span></p>
-                                                                    <p class="consolas" style="font-size: medium">{{ i.feedback.display_solucion.decode | safe }}</p>
-                                                                <hr>
+                                                        <div class="collapsible-body codigos-body">
+                                                            {% for test in tests_caso %}
+                                                                {% if test.output_obtenido == form.instance.output_obtenido %}
+                                                                  <hr class="linea-rosada">
+                                                                    <p>
+                                                                        <span class="letra_rosada">{{ test.feedback.user }}</span>
+                                                                        <span class="fecha-texto">&nbsp;{{ test.feedback.fecha_envio }}</span>
+                                                                    </p>
+                                                                    <p class="consolas" style="font-size: medium">{{ test.feedback.display_solucion.decode | safe }}</p>
+                                                                {% endif %}
                                                             {% endfor %}
-
-
                                                         </div>
                                                     </li>
                                                 </ul>
                                             </th>
-
-
                                         </tr>
                                     {% endfor %}
                                 {% else %}
-                                    <tr class="tabla-modal">
+                                    <tr class="row_bad_feedback">
                                          <td colspan="4"><span class="letra_rosada">No se han recibido errores para este caso</span></td>
                                     </tr>
                                 {% endif %}
                                 </tbody>
                             </table>
-
-
                         <div style="display: flex; justify-content: flex-end">
                             <button type="submit" class="btn btn-small modal-close" style="margin-top:1em">Guardar y salir<span><i class="material-icons right">save</i></span></button>
                         </div>
@@ -80,31 +79,50 @@
             <div id="outputs-alternativos" style="margin-top: 2em">
                 <h5>Sugerencias agregadas</h5>
                  <div style="max-width: 100%; overflow-x:auto">
+                    <div class="list"></div>
                     <table id='tabla-output-agregado' class="data-feedback" >
                         <thead>
-                            <tr class="tabla-modal">
+                            <tr class="row_good_feedback">
                                 <th>Output recibido</th>
-                                <th>Código</th>
                                 <th>Sugerencia</th>
-
                             </tr>
                         </thead>
                         <tbody>
                             {% if outputs_agregados %}
                                 {% for output in outputs_agregados %}
-                                    <tr class=" tabla-modal">
+                                    <tr class="row_bad_feedback">
                                         <td class="consolas">{{ output.output_obtenido }}</td>
-                                        <td><div style="display: inline-flex;justify-content: center">
-                                            <button class="btn btn-small" style="margin-top: 0">
-                                                <i class="material-icons" style="vertical-align: middle">text_snippet</i>
-                                                <span style="padding-left: 0.5em; font-size: larger; line-height: 0">({{ output.frecuencia }})</span>
-                                            </button>
-                                        </div></td>
                                         <td>{{ output.sugerencia }}</td>
                                     </tr>
+                                    <tr class="row_bad_feedback">
+                                            <th class="codigos-casos" colspan="2">
+                                                <ul class="collapsible expandable no-sombra">
+                                                    <li class="codigos-header">
+                                                        <div class="collapsible-header">
+                                                            <div class="btn btn-small">
+                                                                <i class="material-icons" style="vertical-align: middle">expand_more</i>
+                                                                <span>CÓDIGOS ({{ output.frecuencia }})</span>
+                                                            </div>
+                                                        </div>
+                                                        <div class="collapsible-body codigos-body">
+                                                            {% for test in tests_caso %}
+                                                                {% if test.output_obtenido == output.output_obtenido %}
+                                                                  <hr class="linea-rosada">
+                                                                    <p>
+                                                                        <span class="letra_rosada">{{ test.feedback.user }}</span>
+                                                                        <span class="fecha-texto">&nbsp;{{ test.feedback.fecha_envio }}</span>
+                                                                    </p>
+                                                                    <p class="consolas" style="font-size: medium">{{ test.feedback.display_solucion.decode | safe }}</p>
+                                                                {% endif %}
+                                                            {% endfor %}
+                                                        </div>
+                                                    </li>
+                                                </ul>
+                                            </th>
+                                        </tr>
                                 {% endfor %}
                             {% else %}
-                                <tr class="tabla-modal">
+                                <tr class="row_bad_feedback">
                                     <td colspan="4"><span class="letra_rosada"> No se han agregado sugerencias aún. </span></td>
                                 </tr>
                             {% endif %}

--- a/problemas/templates/problemas/modal_casos_alternativos.html
+++ b/problemas/templates/problemas/modal_casos_alternativos.html
@@ -40,10 +40,10 @@
                                                 <ul class="collapsible expandable no-sombra">
                                                     <li class="codigos-header">
                                                         <div class="collapsible-header">
-                                                            <div class="btn btn-small">
+                                                              <div class="btn-small btn btn-no-bg">
                                                                 <i class="material-icons" style="vertical-align: middle">expand_more</i>
-                                                                <span>CÓDIGOS ({{ form.instance.frecuencia }})</span>
-                                                            </div>
+                                                                <span>Códigos &nbsp;({{ form.instance.frecuencia }})</span>
+                                                              </div>
                                                         </div>
                                                         <div class="collapsible-body codigos-body">
                                                             {% for test in tests_caso %}

--- a/problemas/templates/problemas/modal_casos_alternativos.html
+++ b/problemas/templates/problemas/modal_casos_alternativos.html
@@ -16,38 +16,81 @@
 
             <div id="outputs-sugeridos" style="margin-top:2em">
                 <h5>Outputs recibidos</h5>
-
                     <div style="max-width: 100%; overflow-x:auto">
-                    <form method="post" action="{% url 'feedback:actualizar-outputs-alternativos' caso_id=id_caso%}" class="list">
-                        {% csrf_token %}
-                        {{ formset.management_form }}
-                        <table id='tabla-output-sugerido' class="data-feedback" >
-                            <thead>
-                                <tr class="tabla-modal">
-                                    <th>Output recibido</th>
-                                    <th>Frecuencia</th>
-                                    <th>Sugerencia</th>
-                                </tr>
-                            </thead>
-                            <tbody>
+                        <form method="post" action="{% url 'feedback:actualizar-outputs-alternativos' caso_id=id_caso%}" class="list">
+                            {% csrf_token %}
+                            {{ formset.management_form }}
+                            <table id='tabla-output-sugerido' class="data-feedback">
+                                <thead>
+                                    <tr class="row_good_feedback">
+                                        <th>Output recibido</th>
+                                        <th>Sugerencia</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
                                 {% if outputs_sugeridos %}
-
                                     {% for form in formset %}
                                         {{ form.id }}
-                                            <tr class=" tabla-modal">
-                                                <td class="consolas">{{  form.instance.output_obtenido}}</td>
-                                                <td >{{ form.instance.frecuencia }}</td>
-                                                <td>{{ form.sugerencia }}</td>
-                                            </tr>
-                                    {% endfor %}
+                                        <tr class="row_bad_feedback ">
+                                            <td class="consolas">{{  form.instance.output_obtenido}}</td>
+                                            <td>{{ form.sugerencia }}</td>
+                                        </tr>
+                                        <tr class="row_bad_feedback">
+                                            <th class="codigos-casos letra_rosada" colspan="2" >
+                                                <ul class="collapsible expandable">
+                                                    <li>
+                                                        <div class="collapsible-header">
+                                                            <i class="material-icons">expand_more</i>
+                                                            Códigos ({{ form.instance.frecuencia }})
+                                                        </div>
+                                                        <div class="collapsible-body" style="text-align: left">
 
+                                                                <p class="consolas">Camila Rodríguez, 19 de abril 2020, 10:45 am</p>
+                                                            <p>#include </p>
+                                                            <p>using namespace</p>
+                                                            <p>int main() {</p>
+                                                            <p>}</p>
+                                                        <hr>
+                                                            <p class="consolas">Camila Rodríguez, 19 de abril 2020, 10:45 am</p>
+                                                            <p>#include iostream
+
+using namespace std;<br>
+
+int main(){<br>
+    int agno;<br>
+    cin >> agno;<br>
+
+    if(agno%4==0 && agno%100!=0){<br>
+        cout << "Yes" << endl;<br>
+    }<br>
+    else if (agno%400==0){<br>
+        cout << "Yes" << endl;<br>
+    }<br>
+    else{<br>
+        cout << "No" << endl;<br>
+
+    }<br>
+    return 0;
+
+}</p>
+
+                                                        </div>
+                                                    </li>
+                                                </ul>
+                                            </th>
+
+
+                                        </tr>
+                                    {% endfor %}
                                 {% else %}
-                                     <tr class="tabla-modal">
+                                    <tr class="tabla-modal">
                                          <td colspan="4"><span class="letra_rosada">No se han recibido errores para este caso</span></td>
                                     </tr>
                                 {% endif %}
-                            </tbody>
-                        </table>
+                                </tbody>
+                            </table>
+
+
                         <div style="display: flex; justify-content: flex-end">
                             <button type="submit" class="btn btn-small modal-close" style="margin-top:1em">Guardar y salir<span><i class="material-icons right">save</i></span></button>
                         </div>
@@ -56,13 +99,13 @@
             </div>
 
             <div id="outputs-alternativos" style="margin-top: 2em">
-                <h5>Outputs agregados</h5>
+                <h5>Sugerencias agregadas</h5>
                  <div style="max-width: 100%; overflow-x:auto">
                     <table id='tabla-output-agregado' class="data-feedback" >
                         <thead>
                             <tr class="tabla-modal">
                                 <th>Output recibido</th>
-                                <th>Frecuencia</th>
+                                <th>Código</th>
                                 <th>Sugerencia</th>
 
                             </tr>
@@ -72,13 +115,18 @@
                                 {% for output in outputs_agregados %}
                                     <tr class=" tabla-modal">
                                         <td class="consolas">{{ output.output_obtenido }}</td>
-                                        <td >{{ output.frecuencia }}</td>
+                                        <td><div style="display: inline-flex;justify-content: center">
+                                            <button class="btn btn-small" style="margin-top: 0">
+                                                <i class="material-icons" style="vertical-align: middle">text_snippet</i>
+                                                <span style="padding-left: 0.5em; font-size: larger; line-height: 0">({{ output.frecuencia }})</span>
+                                            </button>
+                                        </div></td>
                                         <td>{{ output.sugerencia }}</td>
                                     </tr>
                                 {% endfor %}
                             {% else %}
                                 <tr class="tabla-modal">
-                                    <td colspan="4"><span class="letra_rosada"> No se han agregado casos aún. </span></td>
+                                    <td colspan="4"><span class="letra_rosada"> No se han agregado sugerencias aún. </span></td>
                                 </tr>
                             {% endif %}
                         </tbody>
@@ -89,3 +137,11 @@
         </div>
     </div>
 </div>
+
+{% block scripts %}
+    <script>
+        $(document).ready(function() {
+            $('.collapsible').collapsible();
+        })
+    </script>
+{% endblock %}

--- a/problemas/templates/problemas/modal_casos_alternativos.html
+++ b/problemas/templates/problemas/modal_casos_alternativos.html
@@ -43,36 +43,15 @@
                                                             <i class="material-icons">expand_more</i>
                                                             Códigos ({{ form.instance.frecuencia }})
                                                         </div>
-                                                        <div class="collapsible-body" style="text-align: left">
+                                                        <div class="collapsible-body" style="text-align: left;color:black">
 
-                                                                <p class="consolas">Camila Rodríguez, 19 de abril 2020, 10:45 am</p>
-                                                            <p>#include </p>
-                                                            <p>using namespace</p>
-                                                            <p>int main() {</p>
-                                                            <p>}</p>
-                                                        <hr>
-                                                            <p class="consolas">Camila Rodríguez, 19 de abril 2020, 10:45 am</p>
-                                                            <p>#include iostream
+                                                            {% for i in tests_caso %}
 
-using namespace std;<br>
+                                                                    <p><span>{{ i.feedback.user }}</span><span class="letra_gris" style="font-size: smaller">&nbsp;{{ i.feedback.fecha_envio }}</span></p>
+                                                                    <p class="consolas" style="font-size: medium">{{ i.feedback.display_solucion.decode | safe }}</p>
+                                                                <hr>
+                                                            {% endfor %}
 
-int main(){<br>
-    int agno;<br>
-    cin >> agno;<br>
-
-    if(agno%4==0 && agno%100!=0){<br>
-        cout << "Yes" << endl;<br>
-    }<br>
-    else if (agno%400==0){<br>
-        cout << "Yes" << endl;<br>
-    }<br>
-    else{<br>
-        cout << "No" << endl;<br>
-
-    }<br>
-    return 0;
-
-}</p>
 
                                                         </div>
                                                     </li>

--- a/problemas/templatetags/template_tags.py
+++ b/problemas/templatetags/template_tags.py
@@ -4,3 +4,10 @@ from django.template.defaulttags import register
 def lookup(value, arg):
     return value[arg]
 
+@register.filter(name='output_exists')
+def output_exists(value, arg):
+    total = 0
+    for element in arg:
+        total += value[element.id]
+    return total
+

--- a/static/scss/mi_materialize.scss
+++ b/static/scss/mi_materialize.scss
@@ -123,6 +123,15 @@ li.active> .collapsible-header{
   margin-bottom: 5px;
 }
 
+.btn-no-bg {
+  background-color: transparent;
+  color: $primary-color;
+}
+
+.btn-no-bg:hover {
+  color: white;
+}
+
 nav {
   background-color: $primary-color;
   height:70px;

--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -28,7 +28,7 @@ $not-enabled-color: #80868b;
 }
 #casos-de-prueba > tbody > tr:nth-child(even) {background-color: #f2f2f2;}
 
-.tabla-modal > td, .tabla-modal > th{
+.tabla-modal > td, .tabla-modal > th {
   padding: 10px;
   border-bottom: 1px solid $not-enabled-color ;
   border-top: 1px solid #ddd;
@@ -37,7 +37,7 @@ $not-enabled-color: #80868b;
   text-align: center;
 }
 
-tr.row_good_feedback > td , tr.row_good_feedback > th{
+tr.row_good_feedback > td , tr.row_good_feedback > th {
   padding: 10px;
   border-top: 2px solid #ddd;
   border-bottom: 2px solid $not-enabled-color ;
@@ -45,10 +45,10 @@ tr.row_good_feedback > td , tr.row_good_feedback > th{
   max-width: 5em;
   word-wrap: break-word;
 }
+
 tr.row_bad_feedback > td {
   padding: 10px;
-  border-top: 1px solid #ddd;
-  border-bottom: #ffffff;
+  border: 1px solid #fff;
   text-align: center;
   max-width: 5em;
   word-wrap: break-word;
@@ -59,7 +59,6 @@ tr.row_bad_feedback> td.sugerencia{
   padding-left: 20px;
   padding-bottom:1.5em;
   border-bottom: 2px solid $not-enabled-color;
-  border-top: #ffffff;
   text-align: center;
   max-width: 5em;
   word-wrap: break-word;
@@ -84,7 +83,16 @@ tr.row_bad_feedback> td.sugerencia{
   align-items: center;
 }
 
-
+tr.row_bad_feedback> th.codigos-casos {
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-top: 0;
+  border: 1px solid #fff;
+  border-bottom: 2px solid $not-enabled-color;
+  text-align: center;
+  max-width: 5em;
+  word-wrap: break-word;
+}
 
 
 td, th {
@@ -99,6 +107,7 @@ td, th {
   border-left: 1px solid #ddd;
   border-bottom: #ffffff;
 }
+
 .tabla-asistencia-alumna {
     table-layout: fixed;
     width: 80%;

--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -14,6 +14,12 @@ $not-enabled-color: #80868b;
 .letra_gris {
   color: $not-enabled-color;
 }
+
+.fecha-texto {
+  font-size: smaller;
+  color: $not-enabled-color;
+  font-weight: normal;
+}
 .container {
   margin-top: 2em;
 }
@@ -52,7 +58,7 @@ tr.row_good_feedback > td , tr.row_good_feedback > th {
 
 tr.row_bad_feedback > td {
   padding: 10px;
-  border: 1px solid #fff;
+  border: 1px solid transparent;
   text-align: center;
   max-width: 5em;
   word-wrap: break-word;
@@ -91,7 +97,7 @@ tr.row_bad_feedback> th.codigos-casos {
   padding-top: 0;
   padding-bottom: 0;
   margin-top: 0;
-  border: 1px solid #fff;
+  border: transparent;
   border-bottom: 2px solid $not-enabled-color;
   text-align: center;
   max-width: 5em;
@@ -107,9 +113,29 @@ td, th {
 }
 
 .row_bad_feedback{
-  border-right: 1px solid #ddd;
-  border-left: 1px solid #ddd;
+  border-right: transparent;
+  border-left: transparent;
   border-bottom: #ffffff;
+}
+
+.codigos-body {
+  padding: 1em 0 0;
+  text-align: left;
+  color:black;
+  border-bottom: transparent;
+}
+
+.codigos-header > .collapsible-header {
+  background-color: transparent!important;
+  border-bottom: transparent;
+  color: $primary-color;
+  font-weight: normal;
+  padding: 0;
+}
+
+.no-sombra {
+  box-shadow: none!important;
+  border: transparent
 }
 
 .tabla-asistencia-alumna {
@@ -343,6 +369,11 @@ hr.problemas-line {
   border: 1px dotted $not-enabled-color;
 }
 
+hr.linea-rosada {
+  background-color: $hover-color;
+  border: 1px solid $hover-color
+}
+
 
 .feedback-bueno {
   background-color: $check-color
@@ -379,3 +410,22 @@ hr.problemas-line {
 .notification:hover .badge {
   background-color: $primary-color;
 }
+
+.big-badge {
+  border-radius: 50%;
+  background-color: $primary-color;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 2px;
+  color: white;
+}
+
+#casos-categoria.active .big-badge {
+  display: none;
+}
+
+
+
+
+
+

--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -331,3 +331,27 @@ hr.problemas-line {
 .tab_content {
   padding: 1em;
 }
+
+.notification {
+  background-color: $hover-color;
+  text-decoration: none;
+  position: relative;
+  display: inline-block;
+}
+
+.notification .badge {
+  position: absolute;
+  min-width: 1.5rem;
+  line-height: 0;
+  margin-left: 10px;
+  top: -10px;
+  right: -10px;
+  padding: 10px 5px;
+  border-radius: 50%;
+  background-color: $hover-color;
+  color: white
+}
+
+.notification:hover .badge {
+  background-color: $primary-color;
+}

--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -131,6 +131,7 @@ td, th {
   color: $primary-color;
   font-weight: normal;
   padding: 0;
+  width: fit-content;
 }
 
 .no-sombra {
@@ -415,7 +416,7 @@ hr.linea-rosada {
 }
 
 .big-badge {
-  border-radius: 50%;
+  border-radius: 25px;
   background-color: $primary-color;
   padding-left: 10px;
   padding-right: 10px;


### PR DESCRIPTION
- Códigos de alumnas aparecen en modal de outputs alternativos (se podría corregir que la parte clickeable de códigos abarca más de lo que debería, pero no es tan importante por ahora).
- En menú de casos de prueba se desactivó que una categoría estuviese activa por defecto (causaba que hubiese que apretar dos veces para abrir el resto). Se añadió un contador de los nuevos outputs de esa categoría.
- Notificación de nuevos outputs por caso ya no parece botón.